### PR TITLE
Bugfix/4175

### DIFF
--- a/packages/webchat/package.json
+++ b/packages/webchat/package.json
@@ -7,7 +7,7 @@
     "main": "lib/webchat/index.js",
     "scripts": {
         "build": "tsc",
-        "bundle": "yarn webchat && yarn webchat-legacy && yarn speech-input && yarn speech-input-legacy && yarn speech-output && yarn speech-output-legacy && yarn flightseat-picker && yarn flightseat-picker-legacy",
+        "bundle": "yarn webchat && yarn webchat-legacy && yarn speech-input && yarn speech-input-legacy && yarn speech-output && yarn speech-output-legacy && yarn flightseat-picker && yarn flightseat-picker-legacy && yarn date-picker && yarn date-picker-legacy",
         "dev": "webpack-dev-server --config webpack.dev.js --content-base dist/ --host 0.0.0.0 --disable-host-check",
         "date-picker-legacy": "webpack --config webpack.production.legacy.js --entry ./src/plugins/message/date-picker/index.tsx --output dist/date-picker.webchat-plugin.legacy.js",
         "date-picker": "webpack --config webpack.production.js --entry ./src/plugins/message/date-picker/index.tsx --output dist/date-picker.webchat-plugin.js",

--- a/packages/webchat/src/plugins/message/date-picker/index.tsx
+++ b/packages/webchat/src/plugins/message/date-picker/index.tsx
@@ -212,9 +212,9 @@ const datePickerPlugin: MessagePluginFactory = ({ styled }) => {
       const { onSendMessage, message, config, attributes, isFullscreen, onSetFullscreen } = this.props;
 
 
-      let dateButtonText = message.data._plugin.data.openPickerButtonText;
-      let cancelButtonText = message.data._plugin.data.cancelButtonText;
-      let submitButtonText = message.data._plugin.data.submitButtonText;
+      let dateButtonText = message.data._plugin.data.openPickerButtonText || 'pick date';
+      let cancelButtonText = message.data._plugin.data.cancelButtonText || 'cancel';
+      let submitButtonText = message.data._plugin.data.submitButtonText || 'submit';
 
       const options = DatePicker.getOptionsFromMessage(message);
 

--- a/packages/webchat/src/plugins/message/date-picker/index.tsx
+++ b/packages/webchat/src/plugins/message/date-picker/index.tsx
@@ -211,9 +211,10 @@ const datePickerPlugin: MessagePluginFactory = ({ styled }) => {
     render() {
       const { onSendMessage, message, config, attributes, isFullscreen, onSetFullscreen } = this.props;
 
-      let dateButtonText = "pick date";
-      let cancelButtonText = "cancel";
-      let submitButtonText = "submit";
+
+      let dateButtonText = message.data._plugin.data.openPickerButtonText;
+      let cancelButtonText = message.data._plugin.data.cancelButtonText;
+      let submitButtonText = message.data._plugin.data.submitButtonText;
 
       const options = DatePicker.getOptionsFromMessage(message);
 


### PR DESCRIPTION
Fixed the bug ticket 4175. 

The plugin didn't take the button texts from the date picker node. Instead, it just used a default text.